### PR TITLE
Removing clutter in `pelicanconf.py`.

### DIFF
--- a/src/turbopelican/newsite/pelicanconf.py
+++ b/src/turbopelican/newsite/pelicanconf.py
@@ -28,18 +28,10 @@ AUTHOR_FEED_ATOM = None
 AUTHOR_FEED_RSS = None
 
 # Blogroll
-LINKS = (
-    ("Pelican", "https://getpelican.com/"),
-    ("Python.org", "https://www.python.org/"),
-    ("Jinja2", "https://palletsprojects.com/p/jinja/"),
-    ("You can modify those links in your config file", "#"),
-)
+LINKS = ()
 
 # Social widget
-SOCIAL = (
-    ("You can add links in your config file", "#"),
-    ("Another social link", "#"),
-)
+SOCIAL = ()
 
 DEFAULT_PAGINATION = False
 


### PR DESCRIPTION
This file is already quite long. It is better for it to be condensed. Social media and links are not useful enough to the user that they should be handled by Pelican by default.