### PR TITLE
Replacing ValueError with FileNotFoundError.

### DIFF
--- a/src/turbopelican/commands/init/create.py
+++ b/src/turbopelican/commands/init/create.py
@@ -39,7 +39,7 @@ def generate_repository(directory: Path, *, verbosity: Verbosity) -> None:
         verbosity: Whether or not to suppress output.
     """
     if not directory.parent.exists():
-        raise ValueError(
+        raise FileNotFoundError(
             f"Cannot create repository. {directory.parent} does not exist.",
         )
     if directory.exists():


### PR DESCRIPTION
When a user tries creating a new repository, but the parent of the repository they provided does not exist, the error is now a `FileNotFoundError`, which is more accurate.