### PR TITLE
Running `uv sync` after `pyproject.toml` update.

### DIFF
--- a/src/turbopelican/commands/init/create.py
+++ b/src/turbopelican/commands/init/create.py
@@ -60,8 +60,6 @@ def generate_repository(directory: Path, *, verbosity: Verbosity) -> None:
     git_use_main_branch = [git_path, "branch", "-m", "main"]
     subprocess.run(git_use_main_branch, check=True, cwd=directory)
 
-    uv_sync(directory, verbosity=verbosity)
-
 
 def update_website(args: TurboConfiguration) -> None:
     """Updates the Pelican website to use the provided information.

--- a/src/turbopelican/commands/init/init.py
+++ b/src/turbopelican/commands/init/init.py
@@ -9,6 +9,7 @@ from turbopelican.commands.init.create import (
     generate_repository,
     update_pyproject,
     update_website,
+    uv_sync,
 )
 
 if TYPE_CHECKING:
@@ -86,3 +87,4 @@ def command(raw_args: Namespace) -> None:
     generate_repository(config.directory, verbosity=config.verbosity)
     update_website(config)
     update_pyproject(config.directory)
+    uv_sync(directory=config.directory, verbosity=config.verbosity)


### PR DESCRIPTION
Previously `uv sync` was run *before* the project metadata was complete. While this shouldn't be an issue, it may become one in the future, so fixing now.