### PR TITLE
Intercepting the LanguageTagError.

### DIFF
--- a/src/turbopelican/commands/init/config.py
+++ b/src/turbopelican/commands/init/config.py
@@ -278,7 +278,12 @@ class TurboConfiguration(BaseModel):
         if not chosen_lang:
             return "en"
 
-        if not langcodes.Language.get(chosen_lang).is_valid():
+        # Raise exception if the language doesn't appear to be valid.
+        try:
+            language = langcodes.Language.get(chosen_lang)
+        except langcodes.LanguageTagError:
+            raise ConfigurationError(f"Invalid language: {chosen_lang}") from None
+        if not language.is_valid():
             raise ConfigurationError(f"Invalid language: {chosen_lang}")
 
         return chosen_lang

--- a/src/turbopelican/commands/init/tests/test_config.py
+++ b/src/turbopelican/commands/init/tests/test_config.py
@@ -464,7 +464,6 @@ def test_turbo_configuration_get_default_lang_input_empty() -> None:
     assert default_lang == "en"
 
 
-@pytest.mark.xfail(strict=True)
 @pytest.mark.usefixtures("input_asia_tbilisi")
 def test_turbo_configuration_get_default_lang_input_unparseable() -> None:
     """Ensures error when an unparseable language is provided."""


### PR DESCRIPTION
Running `langcodes.Language.get` can sometimes fail with a `LanguageTagError`. Instead fixing to raise a `ConfigurationError`, which provides greater clarity on the problem.