### PR TITLE
Eliminate ConfigurationError on valid URL bug.

### DIFF
--- a/src/turbopelican/commands/init/config.py
+++ b/src/turbopelican/commands/init/config.py
@@ -351,7 +351,7 @@ class TurboConfiguration(BaseModel):
         elif input_mode == InputMode.REJECT_INPUT:
             raise ConfigurationError("Could not obtain site URL without user input.")
         else:
-            chosen_name = input("What is your website URL? ").removesuffix(".github.io")
+            chosen_name = input("What is your website URL? ")
             if not chosen_name:
                 raise ConfigurationError("Website URL not provided.")
 

--- a/src/turbopelican/commands/init/tests/test_config.py
+++ b/src/turbopelican/commands/init/tests/test_config.py
@@ -619,7 +619,6 @@ def test_turbo_configuration_get_site_url_valid_path_input_valid() -> None:
     assert site_url == "https://mysite.github.io"
 
 
-@pytest.mark.xfail(strict=True)
 @pytest.mark.usefixtures("input_site_name")
 def test_turbo_configuration_get_site_url_invalid_path_input_valid() -> None:
     """Ensures error raised if URL can't be inferred and user enters one."""


### PR DESCRIPTION
When the user was prompted for a site URL without a suggestion, it was impossible for the user to provide a valid site URL without it being rejected as a necessary component thereof was stripped mistakenly.