### PR TITLE
Silencing uv warnings in CI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ type-check:
 
 integration-test:
 	uv run turbopelican init --author "GNU make" "$(TARGET)" -nd
-	uv run --directory "$(TARGET)" pelican content
-	uv run --directory "$(TARGET)" pelican -s publishconf.py content
+	VIRTUAL_ENV="$(TARGET)/.venv" uv run --directory "$(TARGET)" pelican content
+	VIRTUAL_ENV="$(TARGET)/.venv" uv run --directory "$(TARGET)" pelican -s publishconf.py content
 	@rm -rf "$(TEMP_DIR)"
 
 ci: lint format test type-check integration-test

--- a/src/turbopelican/_commands/init/create.py
+++ b/src/turbopelican/_commands/init/create.py
@@ -31,7 +31,14 @@ def uv_sync(directory: Path, *, verbosity: Verbosity) -> None:
     uv_sync_args = [uv_path, "sync"]
     if verbosity == Verbosity.QUIET:
         uv_sync_args.append("--quiet")
-    subprocess.run(uv_sync_args, check=True, cwd=directory)
+
+    try:
+        subprocess.run(
+            uv_sync_args, check=True, cwd=directory, text=True, capture_output=True
+        )
+    except subprocess.CalledProcessError as exc:
+        exc.add_note(exc.stderr)
+        raise
 
 
 def generate_repository(directory: Path, *, verbosity: Verbosity) -> None:

--- a/src/turbopelican/_commands/init/tests/test_create.py
+++ b/src/turbopelican/_commands/init/tests/test_create.py
@@ -52,6 +52,8 @@ def test_uv_sync(mock_subprocess_run: mock.Mock) -> None:
         ["/usr/bin/uv", "sync"],
         check=True,
         cwd=Path(),
+        text=True,
+        capture_output=True,
     )
 
 
@@ -63,6 +65,8 @@ def test_uv_sync_quiet(mock_subprocess_run: mock.Mock) -> None:
         ["/usr/bin/uv", "sync", "--quiet"],
         check=True,
         cwd=Path(),
+        text=True,
+        capture_output=True,
     )
 
 


### PR DESCRIPTION
There is a problem when running `uv sync` or `uv run` while the `turbopelican` virtual environment is activated, which means uv will warn the developer that one virtual environment is activated while the virtual environment being touched is different. This should silence the warning, as the intended behaviour is to ignore the activated virtual environment.