### PR TITLE
Using special function to copy template.

### DIFF
--- a/src/turbopelican/_commands/init/create.py
+++ b/src/turbopelican/_commands/init/create.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 from datetime import datetime
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 from zoneinfo import ZoneInfo
 
 import tomlkit
@@ -41,6 +41,19 @@ def uv_sync(directory: Path, *, verbosity: Verbosity) -> None:
         raise
 
 
+def _copy_template(directory: Path, name: Literal["newsite", "minimal"]) -> None:
+    """Copies all the files from a template over.
+
+    Args:
+        directory: The path where the repository is to be initialized.
+        name: The name of the template to copy.
+    """
+    with pkg_resources.as_file(
+        pkg_resources.files(__name__.split(".", 1)[0]).joinpath("_templates", name)
+    ) as p:
+        shutil.copytree(p, directory, dirs_exist_ok=True)
+
+
 def generate_repository(directory: Path, *, verbosity: Verbosity) -> None:
     """Generates the files in place for turbopelican to use.
 
@@ -54,12 +67,7 @@ def generate_repository(directory: Path, *, verbosity: Verbosity) -> None:
         )
     if directory.exists():
         directory.rmdir()
-    with pkg_resources.as_file(
-        pkg_resources.files(__name__.split(".", 1)[0]).joinpath(
-            "_templates", "newsite"
-        ),
-    ) as p:
-        shutil.copytree(p, directory)
+    _copy_template(directory, "newsite")
 
     git_path = shutil.which("git")
     if git_path is None:

--- a/src/turbopelican/_commands/init/tests/test_create.py
+++ b/src/turbopelican/_commands/init/tests/test_create.py
@@ -15,6 +15,7 @@ from turbopelican._commands.init.config import (
     Verbosity,
 )
 from turbopelican._commands.init.create import (
+    _copy_template,
     generate_repository,
     update_contents,
     update_pyproject,
@@ -75,6 +76,22 @@ def test_uv_sync_missing(mock_subprocess_run: mock.Mock) -> None:
     """Tests that repository is synced appropriately."""
     uv_sync(Path(), verbosity=Verbosity.NORMAL)
     mock_subprocess_run.assert_not_called()
+
+
+def test_copy_template(tmp_path: Path) -> None:
+    """Tests that a template can be copied successfully.
+
+    Args:
+        tmp_path: A temporary and empty directory.
+    """
+    copy_to = tmp_path / "copy_here"
+    copy_to.mkdir()
+    _copy_template(copy_to, "newsite")
+    path_to_conf = copy_to / "pelicanconf.py"
+    original_text = path_to_conf.read_text()
+    _copy_template(copy_to, "minimal")
+    assert path_to_conf.read_text() != original_text
+    assert (copy_to / "turbopelican.toml").exists()
 
 
 def test_generate_repository_bad_directory(tmp_path: Path) -> None:


### PR DESCRIPTION
The template also does not raise an error when overriding other files. This is intentional so that templates can be overlaid.