### PR TITLE
Allowing a minimal installation via flag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,20 @@ type-check:
 	uv run pyright
 
 integration-test:
+	# Run normally.
 	uv run turbopelican init --author "GNU make" "$(TARGET)" -nd
 	VIRTUAL_ENV="$(TARGET)/.venv" uv pip --directory "$(TARGET)" install -qe "$(shell pwd)"
 	VIRTUAL_ENV="$(TARGET)/.venv" uv run --directory "$(TARGET)" --no-sync pelican content
 	VIRTUAL_ENV="$(TARGET)/.venv" uv run --directory "$(TARGET)" --no-sync pelican -s publishconf.py content
+
+	# Run with a minimal install.
+	@rm -rf "$(TARGET)"
+	uv run turbopelican init --author "GNU make" "$(TARGET)" -nd --minimal-install
+	VIRTUAL_ENV="$(TARGET)/.venv" uv pip --directory "$(TARGET)" install -qe "$(shell pwd)"
+	VIRTUAL_ENV="$(TARGET)/.venv" uv run --directory "$(TARGET)" --no-sync pelican content
+	VIRTUAL_ENV="$(TARGET)/.venv" uv run --directory "$(TARGET)" --no-sync pelican -s publishconf.py content
+
+	# Clean up.
 	@rm -rf "$(TEMP_DIR)"
 
 ci: lint format test type-check integration-test

--- a/src/turbopelican/_commands/init/config.py
+++ b/src/turbopelican/_commands/init/config.py
@@ -39,6 +39,13 @@ class HandleDefaultsMode(StrEnum):
     USE_DEFAULTS = "USE_DEFAULTS"
 
 
+class InstallType(StrEnum):
+    """Whether Turbopelican should be installed in the virtual environment or not."""
+
+    MINIMAL_INSTALL = "MINIMAL_INSTALL"
+    FULL_INSTALL = "FULL_INSTALL"
+
+
 class ConfigurationError(ValueError):
     """The configuration cannot be correctly evaluated, due to missing inputs."""
 
@@ -56,6 +63,7 @@ class TurboConfiguration:
     verbosity: Verbosity
     input_mode: InputMode
     handle_defaults_mode: HandleDefaultsMode
+    install_type: InstallType
 
     @classmethod
     def from_args(cls, raw_args: Namespace) -> TurboConfiguration:
@@ -78,6 +86,11 @@ class TurboConfiguration:
             HandleDefaultsMode.USE_DEFAULTS
             if raw_args.use_defaults
             else HandleDefaultsMode.REQUIRE_STANDARD_INPUT
+        )
+        install_type = (
+            InstallType.MINIMAL_INSTALL
+            if raw_args.minimal_install
+            else InstallType.FULL_INSTALL
         )
 
         author = cls._get_author(
@@ -119,6 +132,7 @@ class TurboConfiguration:
             verbosity=verbosity,
             input_mode=input_mode,
             handle_defaults_mode=handle_defaults_mode,
+            install_type=install_type,
         )
 
     @staticmethod

--- a/src/turbopelican/_commands/init/init.py
+++ b/src/turbopelican/_commands/init/init.py
@@ -75,6 +75,12 @@ def add_options(parser: ArgumentParser) -> None:
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--minimal-install",
+        help="Do not install turbopelican in the virtual environment.",
+        action="store_true",
+        default=False,
+    )
     parser.set_defaults(func=command)
 
 
@@ -85,7 +91,7 @@ def command(raw_args: Namespace) -> None:
         raw_args: The command-line provided arguments.
     """
     config = TurboConfiguration.from_args(raw_args)
-    generate_repository(config.directory, verbosity=config.verbosity)
+    generate_repository(config)
     update_website(config)
     update_pyproject(config.directory)
     update_contents(config)

--- a/src/turbopelican/_commands/init/tests/test_config.py
+++ b/src/turbopelican/_commands/init/tests/test_config.py
@@ -149,6 +149,7 @@ def test_turbo_configuration_from_args(tmp_path: Path) -> None:
         default_lang=None,
         site_url=None,
         quiet=True,
+        minimal_install=False,
     )
     config = TurboConfiguration.from_args(namespace)
     assert config.directory == new_repo

--- a/src/turbopelican/_templates/minimal/pyproject.toml
+++ b/src/turbopelican/_templates/minimal/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "mypelicansite"
+version = "0.1.0"
+description = "My personal website."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "pelican[markdown]>=4.11.0",
+]

--- a/src/turbopelican/tests/test_args.py
+++ b/src/turbopelican/tests/test_args.py
@@ -20,6 +20,7 @@ def test_get_raw_args_without_subcommand() -> None:
         site_url=None,
         no_input=False,
         func=init.command,
+        minimal_install=False,
     )
 
 
@@ -37,4 +38,5 @@ def test_get_raw_args() -> None:
         site_url=None,
         no_input=False,
         func=init.command,
+        minimal_install=False,
     )


### PR DESCRIPTION
A minimal installation means that the user's only dependency is Turbopelican. This means that the user misses out on Turbopelican's functionality, but may be necessary if Turbopelican's dependencies clash with other dependencies they wish to use.