### PR TITLE
Releasing new versions via GitHub Actions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release new version
+run-name: ${{ github.actor }}
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release-new-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.6.8"
+      - run: make build
+      - run: uv build
+      - name: Publish to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
+        run: uv publish
+      - name: Release via GitHub
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          TO_RELEASE=($(find dist \
+              -type f \
+              \( -name "*.tar.gz" -o -name "*.whl" \) \
+              -printf "%p "))
+          gh release create "$VERSION" --title "$VERSION" "${TO_RELEASE[@]}"


### PR DESCRIPTION
At some point, it would be very good for this to automatically extract all pertinent text from `CHANGELOG.md` to create a version description, rather than requiring a manual edit.