### PR TITLE
Standardizing title/URL pairs in minimal template.

### DIFF
--- a/src/turbopelican/_templates/minimal/pelicanconf.py
+++ b/src/turbopelican/_templates/minimal/pelicanconf.py
@@ -53,12 +53,12 @@ AUTHOR_FEED_RSS = None
 
 # Blogroll
 LINKS: tuple[tuple[str, str], ...] = tuple(
-    (link["title"], link["url"]) for link in turbopelican_config.get("links", [])
+    map(tuple, turbopelican_config.get("links", []))
 )
 
 # Social widget
 SOCIAL: tuple[tuple[str, str], ...] = tuple(
-    (link["title"], link["url"]) for link in turbopelican_config.get("social", [])
+    map(tuple, turbopelican_config.get("social", []))
 )
 
 DEFAULT_PAGINATION: bool = turbopelican_config["default_pagination"]


### PR DESCRIPTION
Prior, using a minimal Turbopelican repository would result in a different expected format for the title and URL pair. Now no longer allowing key/value pairs, only allowing arrays of two-element arrays.