### PR TITLE
Introduce `--use-gh-cli` flag.

### DIFF
--- a/src/turbopelican/_commands/init/config.py
+++ b/src/turbopelican/_commands/init/config.py
@@ -65,6 +65,7 @@ class InitConfiguration:
     handle_defaults_mode: HandleDefaultsMode
     install_type: InstallType
     commit_changes: bool = True
+    use_gh_cli: bool = False
 
     @classmethod
     def from_args(cls, raw_args: Namespace) -> InitConfiguration:
@@ -122,6 +123,9 @@ class InitConfiguration:
             input_mode=input_mode,
             handle_defaults_mode=handle_defaults_mode,
         )
+        commit_changes = cls._get_commit_changes(
+            no_commit=raw_args.no_commit, use_gh_cli=raw_args.use_gh_cli
+        )
 
         return InitConfiguration(
             directory=path,
@@ -134,7 +138,8 @@ class InitConfiguration:
             input_mode=input_mode,
             handle_defaults_mode=handle_defaults_mode,
             install_type=install_type,
-            commit_changes=not raw_args.no_commit,
+            commit_changes=commit_changes,
+            use_gh_cli=raw_args.use_gh_cli,
         )
 
     @staticmethod
@@ -375,3 +380,20 @@ class InitConfiguration:
 
         cls._validate_site_url(chosen_name)
         return chosen_name
+
+    @classmethod
+    def _get_commit_changes(cls, *, no_commit: bool, use_gh_cli: bool) -> bool:
+        """Ensures that non-conflicting instructions are provided for git actions.
+
+        Args:
+            no_commit: If True, does not make any commits.
+            use_gh_cli: If True, creates the remote repository on GitHub automatically.
+
+        Returns:
+            Whether or not to commit the changes.
+        """
+        if use_gh_cli and no_commit:
+            msg = "Cannot run GitHub CLI without committing changes."
+            raise ConfigurationError(msg)
+
+        return not no_commit

--- a/src/turbopelican/_commands/init/init.py
+++ b/src/turbopelican/_commands/init/init.py
@@ -9,6 +9,7 @@ from turbopelican._commands.init.create import (
     commit_changes,
     generate_repository,
     report_completion,
+    run_gh_cli,
     update_contents,
     update_pyproject,
     update_website,
@@ -89,6 +90,12 @@ def add_options(parser: ArgumentParser) -> None:
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--use-gh-cli",
+        help="Create the remote GitHub repository and deploy website automatically.",
+        action="store_true",
+        default=False,
+    )
     parser.set_defaults(func=command)
 
 
@@ -105,4 +112,5 @@ def command(raw_args: Namespace) -> None:
     update_contents(config)
     uv_sync(directory=config.directory, verbosity=config.verbosity)
     commit_changes(config)
+    run_gh_cli(config)
     report_completion(config)

--- a/src/turbopelican/_commands/init/tests/test_config.py
+++ b/src/turbopelican/_commands/init/tests/test_config.py
@@ -151,6 +151,7 @@ def test_turbo_configuration_from_args(tmp_path: Path) -> None:
         quiet=True,
         minimal_install=False,
         no_commit=False,
+        use_gh_cli=False,
     )
     config = InitConfiguration.from_args(namespace)
     assert config.directory == new_repo

--- a/src/turbopelican/tests/test_args.py
+++ b/src/turbopelican/tests/test_args.py
@@ -22,6 +22,7 @@ def test_get_raw_args_without_subcommand() -> None:
         func=init.command,
         minimal_install=False,
         no_commit=False,
+        use_gh_cli=False,
     )
 
 
@@ -41,4 +42,5 @@ def test_get_raw_args() -> None:
         func=init.command,
         minimal_install=False,
         no_commit=False,
+        use_gh_cli=False,
     )


### PR DESCRIPTION
Flag should cause Turbopelican to automatically push the code to GitHub such that it deploys via GitHub Actions.