### PR TITLE
Suggest `turbopelican adorn` as possibility.

### DIFF
--- a/src/turbopelican/_commands/init/create.py
+++ b/src/turbopelican/_commands/init/create.py
@@ -77,6 +77,12 @@ def generate_repository(args: InitConfiguration) -> None:
             f"Cannot create repository. {args.directory.parent} does not exist.",
         )
     if args.directory.exists():
+        if not args.directory.is_dir():
+            raise NotADirectoryError("Cannot create repository at {args.directory}.")
+        if any(args.directory.iterdir()):
+            error_message = f"Non-empty target directory at {args.directory}."
+            tip_message = "Use `turbopelican adorn` to modify existing repository."
+            raise RuntimeError(f"{error_message}\n{tip_message}")
         args.directory.rmdir()
     _copy_template(args.directory, "newsite")
     if args.install_type == InstallType.MINIMAL_INSTALL:

--- a/src/turbopelican/_commands/init/tests/test_create.py
+++ b/src/turbopelican/_commands/init/tests/test_create.py
@@ -135,6 +135,31 @@ def test_generate_repository_bad_directory(config: InitConfiguration) -> None:
         generate_repository(config)
 
 
+def test_generate_repository_not_a_directory(config: InitConfiguration) -> None:
+    """Tests that the appropriate error is raised when a non-directory is given.
+
+    Args:
+        config: The configuration for Turbopelican. Supplied via fixture.
+    """
+    config.directory = config.directory / "myfile"
+    config.directory.touch()
+    with pytest.raises(NotADirectoryError):
+        generate_repository(config)
+
+
+def test_generate_repository_not_empty(config: InitConfiguration) -> None:
+    """Tests that the appropriate error is raised when a non-empty directory is given.
+
+    Args:
+        config: The configuration for Turbopelican. Supplied via fixture.
+    """
+    config.directory = config.directory / "myrepo"
+    config.directory.mkdir()
+    (config.directory / "hello-world.txt").touch()
+    with pytest.raises(RuntimeError):
+        generate_repository(config)
+
+
 @pytest.mark.usefixtures("mock_subprocess_run")
 def test_generate_repository_new_folder(config: InitConfiguration) -> None:
     """Tests that the repository can be generated successfully, creating a new folder.


### PR DESCRIPTION
If a user attempts to run `turbopelican init` on a repository that already has contents within, Turbopelican should advise the user to use `turbopelican adorn` instead to modify the existing repository.