### PR TITLE
Fix use of `turbopelican adorn` outside venv.

### DIFF
--- a/src/turbopelican/_commands/adorn/create.py
+++ b/src/turbopelican/_commands/adorn/create.py
@@ -141,7 +141,7 @@ def install_packages(config: AdornConfiguration) -> None:
         uv_add_args.append("--quiet")
 
     environ = os.environ.copy()
-    environ.pop("VIRTUAL_ENV")
+    environ.pop("VIRTUAL_ENV", None)
 
     subprocess.check_call(uv_add_args, cwd=config.directory, env=environ)
 


### PR DESCRIPTION
When `VIRTUAL_ENV` is not set, `turbopelican adorn` assumes correctly that it is when attempting to unset it. Now it should only be unset if present at all.