### PR TITLE
Correcting typo in word `branches`.

### DIFF
--- a/src/turbopelican/_templates/newsite/.github/workflows/turbopelican.yml
+++ b/src/turbopelican/_templates/newsite/.github/workflows/turbopelican.yml
@@ -2,7 +2,7 @@ name: Build static site
 run-name: ${{ github.actor }}
 on:
   push:
-    braches:
+    branches:
       - main
 jobs:
   build-static-site:


### PR DESCRIPTION
This previously caused the GitHub workflow to attempt a website deployment from all branches, rather than just the `main` branch.