### PR TITLE
Fix wrongly adorned site URL.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ integration-test:
 	# Run `turbopelican adorn` normally.
 	@rm -rf "$(TARGET)"
 	uv init "$(TARGET)"
+	git -C "$(TARGET)" remote add origin "git@github.com:myuser/myrepo"
 	uv run turbopelican adorn --author "GNU make" "$(TARGET)" -nd
 	$(VENV) uv pip --directory "$(TARGET)" install -qe "$(shell pwd)"
 	$(VENV) uv run --directory "$(TARGET)" --no-sync pelican content
@@ -45,6 +46,7 @@ integration-test:
 	# Run `turbopelican adorn` with a minimal install.
 	@rm -rf "$(TARGET)"
 	uv init "$(TARGET)"
+	git -C "$(TARGET)" remote add origin "git@github.com:myuser/myrepo"
 	uv run turbopelican adorn --author "GNU make" "$(TARGET)" -nd --minimal-install
 	$(VENV) uv pip --directory "$(TARGET)" install -qe "$(shell pwd)"
 	$(VENV) uv run --directory "$(TARGET)" --no-sync pelican content

--- a/src/turbopelican/_commands/adorn/tests/test_config.py
+++ b/src/turbopelican/_commands/adorn/tests/test_config.py
@@ -1,3 +1,5 @@
+import shutil
+import subprocess
 from argparse import Namespace
 from pathlib import Path
 
@@ -21,7 +23,7 @@ def test_turbo_configuration_from_args(tmp_path: Path) -> None:
         site_name=None,
         timezone="Pacific/Auckland",
         default_lang=None,
-        site_url=None,
+        site_url="https://owner.github.io/my-website",
         quiet=True,
         minimal_install=False,
         no_commit=False,
@@ -34,5 +36,49 @@ def test_turbo_configuration_from_args(tmp_path: Path) -> None:
     assert config.site_name == "my-website"
     assert config.timezone == "Pacific/Auckland"
     assert config.default_lang == "en"
-    assert config.site_url == "https://my-website.github.io"
+    assert config.site_url == "https://owner.github.io/my-website"
     assert config.verbosity == Verbosity.QUIET
+
+
+def test_adorn_configuration_default_site_url_no_remote(tmp_path: Path) -> None:
+    git_path = shutil.which("git")
+    if git_path is None:
+        raise OSError("git not installed")
+
+    subprocess.check_call([git_path, "init"], cwd=tmp_path)
+
+    assert AdornConfiguration._default_site_url(path=tmp_path) is None
+
+
+def test_adorn_configuration_default_site_url_https_remote(tmp_path: Path) -> None:
+    git_path = shutil.which("git")
+    if git_path is None:
+        raise OSError("git not installed")
+
+    subprocess.check_call([git_path, "init"], cwd=tmp_path)
+    subprocess.check_call(
+        [git_path, "remote", "add", "origin", "https://github.com/hello/world.git"],
+        cwd=tmp_path,
+    )
+
+    assert (
+        AdornConfiguration._default_site_url(path=tmp_path)
+        == "https://hello.github.io/world"
+    )
+
+
+def test_adorn_configuration_default_site_url_ssh_remote(tmp_path: Path) -> None:
+    git_path = shutil.which("git")
+    if git_path is None:
+        raise OSError("git not installed")
+
+    subprocess.check_call([git_path, "init"], cwd=tmp_path)
+    subprocess.check_call(
+        [git_path, "remote", "add", "origin", "git@github.com:hello/world"],
+        cwd=tmp_path,
+    )
+
+    assert (
+        AdornConfiguration._default_site_url(path=tmp_path)
+        == "https://hello.github.io/world"
+    )

--- a/src/turbopelican/_commands/init/config.py
+++ b/src/turbopelican/_commands/init/config.py
@@ -99,6 +99,27 @@ class InitConfiguration(CreateConfiguration):
         )
 
     @classmethod
+    def _default_site_url(cls, path: Path) -> str | None:
+        """Obtains the default site URL if none is provided by the user explicitly.
+
+        Args:
+            path: The resolved path to the directory where the project is located.
+
+        Returns:
+            The default site URL if it can be obtained.
+        """
+        website_name = path.name.removesuffix(".github.io").replace("_", "-")
+        filtered_name = "".join(
+            char
+            for char in website_name
+            if char.isalpha() or char.isdigit() or char == "-"
+        )
+        if filtered_name:
+            return f"https://{filtered_name}.github.io"
+
+        return None
+
+    @classmethod
     def _get_commit_changes(cls, *, no_commit: bool, use_gh_cli: bool) -> bool:
         """Ensures that non-conflicting instructions are provided for git actions.
 

--- a/src/turbopelican/_commands/init/tests/test_config.py
+++ b/src/turbopelican/_commands/init/tests/test_config.py
@@ -37,3 +37,24 @@ def test_turbo_configuration_from_args(tmp_path: Path) -> None:
     assert config.default_lang == "en"
     assert config.site_url == "https://my-website.github.io"
     assert config.verbosity == Verbosity.QUIET
+
+
+def test_turbo_configuration_default_site_url_regular(tmp_path: Path) -> None:
+    """Checks a valid site URL can be inferred from a repository."""
+    assert (
+        InitConfiguration._default_site_url(tmp_path / "repo-name")
+        == "https://repo-name.github.io"
+    )
+
+
+def test_turbo_configuration_default_site_url_explicit(tmp_path: Path) -> None:
+    """Checks a valid site URL can be inferred from a repository with explicit name."""
+    assert (
+        InitConfiguration._default_site_url(tmp_path / "repo_name.github.io")
+        == "https://repo-name.github.io"
+    )
+
+
+def test_turbo_configuration_default_site_url_invalid(tmp_path: Path) -> None:
+    """Checks a valid site URL can be inferred from a repository with explicit name."""
+    assert InitConfiguration._default_site_url(tmp_path / "?") is None

--- a/src/turbopelican/_utils/shared/args.py
+++ b/src/turbopelican/_utils/shared/args.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING
@@ -49,7 +50,7 @@ class ConfigurationError(ValueError):
 
 
 @dataclass
-class CreateConfiguration:
+class CreateConfiguration(ABC):
     """The command line arguments to configure the turbopelican website/project."""
 
     directory: Path
@@ -279,14 +280,8 @@ class CreateConfiguration:
         ):
             raise ConfigurationError("Could not obtain site URL without user input.")
 
-        website_name = path.name.removesuffix(".github.io").replace("_", "-")
-        filtered_name = "".join(
-            char
-            for char in website_name
-            if char.isalpha() or char.isdigit() or char == "-"
-        )
-        if filtered_name:
-            default_url = f"https://{filtered_name}.github.io"
+        default_url = cls._default_site_url(path=path)
+        if default_url:
             if handle_defaults_mode == HandleDefaultsMode.USE_DEFAULTS:
                 return default_url
             chosen_name = input(f"What is your website URL? [{default_url}] ")
@@ -301,3 +296,16 @@ class CreateConfiguration:
 
         cls._validate_site_url(chosen_name)
         return chosen_name
+
+    @classmethod
+    @abstractmethod
+    def _default_site_url(cls, path: Path) -> str | None:
+        """Obtains the default site URL if none is provided by the user explicitly.
+
+        Args:
+            path: The resolved path to the directory where the project is located.
+
+        Returns:
+            The default site URL if it can be obtained.
+        """
+        return NotImplemented

--- a/src/turbopelican/_utils/shared/tests/test_args.py
+++ b/src/turbopelican/_utils/shared/tests/test_args.py
@@ -19,6 +19,36 @@ from turbopelican._utils.shared.args import (
 EnterContext = Generator[None, None, None]
 
 
+class CreateConfigurationValidSiteURL(CreateConfiguration):
+    @classmethod
+    def _default_site_url(cls, path: Path) -> str | None:
+        """Obtains the default site URL if none is provided by the user explicitly.
+
+        Args:
+            path: The resolved path to the directory where the project is located.
+
+        Returns:
+            The default site URL if it can be obtained.
+        """
+        del path
+        return "https://default.github.io"
+
+
+class CreateConfigurationInvalidSiteURL(CreateConfiguration):
+    @classmethod
+    def _default_site_url(cls, path: Path) -> str | None:
+        """Obtains the default site URL if none is provided by the user explicitly.
+
+        Args:
+            path: The resolved path to the directory where the project is located.
+
+        Returns:
+            The default site URL if it can be obtained.
+        """
+        del path
+        return None
+
+
 @pytest.fixture
 def git_cannot_get_author() -> EnterContext:
     """Mock out the subprocess.run function to fail."""
@@ -125,7 +155,7 @@ def available_timezones() -> EnterContext:
 
 def test_turbo_configuration_get_author_cli_provided() -> None:
     """Ensure that the CLI-provided author takes precedence."""
-    author = CreateConfiguration._get_author(
+    author = CreateConfigurationValidSiteURL._get_author(
         "Fred",
         git_path="",
         input_mode=InputMode.ACCEPT_INPUT,
@@ -137,7 +167,7 @@ def test_turbo_configuration_get_author_cli_provided() -> None:
 def test_turbo_configuration_get_author_unavailable() -> None:
     """Ensure that an error is raised when the author cannot be obtained."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_author(
+        CreateConfigurationValidSiteURL._get_author(
             None,
             git_path="",
             input_mode=InputMode.REJECT_INPUT,
@@ -149,7 +179,7 @@ def test_turbo_configuration_get_author_unavailable() -> None:
 def test_turbo_configuration_get_author_git_failure_no_input() -> None:
     """Ensure when git author search fails and input not permitted, error is raised."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_author(
+        CreateConfigurationValidSiteURL._get_author(
             None,
             git_path="",
             input_mode=InputMode.REJECT_INPUT,
@@ -160,7 +190,7 @@ def test_turbo_configuration_get_author_git_failure_no_input() -> None:
 @pytest.mark.usefixtures("git_cannot_get_author", "input_sam")
 def test_turbo_configuration_get_author_git_failure_use_input() -> None:
     """Ensure when git author search fails and input permitted, standard input works."""
-    author = CreateConfiguration._get_author(
+    author = CreateConfigurationValidSiteURL._get_author(
         None,
         git_path="",
         input_mode=InputMode.ACCEPT_INPUT,
@@ -172,7 +202,7 @@ def test_turbo_configuration_get_author_git_failure_use_input() -> None:
 @pytest.mark.usefixtures("git_get_author_fred")
 def test_turbo_configuration_get_author_via_git_succeed_use_default() -> None:
     """Ensure when git author search succeeds, defaults can be returned."""
-    author = CreateConfiguration._get_author(
+    author = CreateConfigurationValidSiteURL._get_author(
         None,
         git_path="",
         input_mode=InputMode.ACCEPT_INPUT,
@@ -184,7 +214,7 @@ def test_turbo_configuration_get_author_via_git_succeed_use_default() -> None:
 @pytest.mark.usefixtures("git_get_author_fred", "input_nothing")
 def test_turbo_configuration_get_author_via_git_succeed_empty_input() -> None:
     """Ensure when git author search succeeds, defaults can be shown."""
-    author = CreateConfiguration._get_author(
+    author = CreateConfigurationValidSiteURL._get_author(
         None,
         git_path="",
         input_mode=InputMode.ACCEPT_INPUT,
@@ -196,7 +226,7 @@ def test_turbo_configuration_get_author_via_git_succeed_empty_input() -> None:
 @pytest.mark.usefixtures("git_get_author_fred", "input_sam")
 def test_turbo_configuration_get_author_via_git_succeed_take_input() -> None:
     """Ensure when git author search succeeds, standard input can be returned."""
-    author = CreateConfiguration._get_author(
+    author = CreateConfigurationValidSiteURL._get_author(
         None,
         git_path="",
         input_mode=InputMode.ACCEPT_INPUT,
@@ -207,7 +237,7 @@ def test_turbo_configuration_get_author_via_git_succeed_take_input() -> None:
 
 def test_turbo_configuration_get_site_name_cli_provided() -> None:
     """Ensure that the CLI-provided author takes precedence."""
-    site_name = CreateConfiguration._get_site_name(
+    site_name = CreateConfigurationValidSiteURL._get_site_name(
         cli_site_name="My Website",
         path=Path("/path/to/website"),
         input_mode=InputMode.ACCEPT_INPUT,
@@ -218,7 +248,7 @@ def test_turbo_configuration_get_site_name_cli_provided() -> None:
 
 def test_turbo_configuration_get_site_name_use_defaults() -> None:
     """Ensure that the site name can be inferred from the path name."""
-    site_name = CreateConfiguration._get_site_name(
+    site_name = CreateConfigurationValidSiteURL._get_site_name(
         cli_site_name=None,
         path=Path("/path/to/website"),
         input_mode=InputMode.ACCEPT_INPUT,
@@ -230,7 +260,7 @@ def test_turbo_configuration_get_site_name_use_defaults() -> None:
 def test_turbo_configuration_get_site_name_unavailable() -> None:
     """Ensure that an error is raised when the path name cannot be obtained."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_site_name(
+        CreateConfigurationValidSiteURL._get_site_name(
             cli_site_name=None,
             path=Path("/path/to/website"),
             input_mode=InputMode.REJECT_INPUT,
@@ -241,7 +271,7 @@ def test_turbo_configuration_get_site_name_unavailable() -> None:
 @pytest.mark.usefixtures("input_my_page")
 def test_turbo_configuration_get_site_name_take_input() -> None:
     """Ensure that the site name can be received via standard input."""
-    site_name = CreateConfiguration._get_site_name(
+    site_name = CreateConfigurationValidSiteURL._get_site_name(
         cli_site_name=None,
         path=Path("/path/to/website"),
         input_mode=InputMode.ACCEPT_INPUT,
@@ -253,7 +283,7 @@ def test_turbo_configuration_get_site_name_take_input() -> None:
 @pytest.mark.usefixtures("input_nothing")
 def test_turbo_configuration_get_site_name_empty_input() -> None:
     """Ensure that the site name, when the user provides no input, can be defaulted."""
-    site_name = CreateConfiguration._get_site_name(
+    site_name = CreateConfigurationValidSiteURL._get_site_name(
         cli_site_name=None,
         path=Path("/path/to/website"),
         input_mode=InputMode.ACCEPT_INPUT,
@@ -264,7 +294,7 @@ def test_turbo_configuration_get_site_name_empty_input() -> None:
 
 def test_turbo_configuration_get_timezone_cli_provided() -> None:
     """Ensure that the timezone can be provided via the CLI."""
-    timezone = CreateConfiguration._get_timezone(
+    timezone = CreateConfigurationValidSiteURL._get_timezone(
         "fr",
         input_mode=InputMode.ACCEPT_INPUT,
         handle_defaults_mode=HandleDefaultsMode.USE_DEFAULTS,
@@ -275,7 +305,7 @@ def test_turbo_configuration_get_timezone_cli_provided() -> None:
 def test_turbo_configuration_get_timezone_unavailable() -> None:
     """Ensures that an error is raised when the timezone cannot be obtained."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_timezone(
+        CreateConfigurationValidSiteURL._get_timezone(
             None,
             input_mode=InputMode.REJECT_INPUT,
             handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
@@ -286,7 +316,7 @@ def test_turbo_configuration_get_timezone_unavailable() -> None:
 def test_turbo_configuration_get_timezone_default_unavailable_no_input() -> None:
     """Ensures error is raised when timezone cannot be obtained and input is blocked."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_timezone(
+        CreateConfigurationValidSiteURL._get_timezone(
             None,
             input_mode=InputMode.REJECT_INPUT,
             handle_defaults_mode=HandleDefaultsMode.USE_DEFAULTS,
@@ -297,7 +327,7 @@ def test_turbo_configuration_get_timezone_default_unavailable_no_input() -> None
 def test_turbo_configuration_get_timezone_default_unavailable_input_empty() -> None:
     """Ensures error is raised when timezone can't be obtained and user inputs blank."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_timezone(
+        CreateConfigurationValidSiteURL._get_timezone(
             None,
             input_mode=InputMode.ACCEPT_INPUT,
             handle_defaults_mode=HandleDefaultsMode.USE_DEFAULTS,
@@ -307,7 +337,7 @@ def test_turbo_configuration_get_timezone_default_unavailable_input_empty() -> N
 @pytest.mark.usefixtures("get_localzone_zoneinfo")
 def test_turbo_configuration_get_timezone_use_default() -> None:
     """Ensures default timezone can be used."""
-    timezone = CreateConfiguration._get_timezone(
+    timezone = CreateConfigurationValidSiteURL._get_timezone(
         None,
         input_mode=InputMode.REJECT_INPUT,
         handle_defaults_mode=HandleDefaultsMode.USE_DEFAULTS,
@@ -319,7 +349,7 @@ def test_turbo_configuration_get_timezone_use_default() -> None:
 def test_turbo_configuration_get_timezone_found_default_input_invalid() -> None:
     """Ensures error is raised if after default found, invalid timezone inputted."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_timezone(
+        CreateConfigurationValidSiteURL._get_timezone(
             None,
             input_mode=InputMode.ACCEPT_INPUT,
             handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
@@ -330,7 +360,7 @@ def test_turbo_configuration_get_timezone_found_default_input_invalid() -> None:
 def test_turbo_configuration_get_timezone_found_no_default_input_invalid() -> None:
     """Ensures error is raised if no default found, invalid timezone inputted."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_timezone(
+        CreateConfigurationValidSiteURL._get_timezone(
             None,
             input_mode=InputMode.ACCEPT_INPUT,
             handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
@@ -344,7 +374,7 @@ def test_turbo_configuration_get_timezone_found_no_default_input_invalid() -> No
 )
 def test_turbo_configuration_get_timezone_found_no_default_input_valid() -> None:
     """Ensures success if when no default found, a valid timezone is inputted."""
-    timezone = CreateConfiguration._get_timezone(
+    timezone = CreateConfigurationValidSiteURL._get_timezone(
         None,
         input_mode=InputMode.ACCEPT_INPUT,
         handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
@@ -359,7 +389,7 @@ def test_turbo_configuration_get_timezone_found_no_default_input_valid() -> None
 )
 def test_turbo_configuration_get_timezone_found_default_input_valid() -> None:
     """Ensures success if after default found, a valid timezone is inputted."""
-    timezone = CreateConfiguration._get_timezone(
+    timezone = CreateConfigurationValidSiteURL._get_timezone(
         None,
         input_mode=InputMode.ACCEPT_INPUT,
         handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
@@ -374,7 +404,7 @@ def test_turbo_configuration_get_timezone_found_default_input_valid() -> None:
 )
 def test_turbo_configuration_get_timezone_found_default_input_empty() -> None:
     """Ensures success if after default found, it is manually chosen."""
-    timezone = CreateConfiguration._get_timezone(
+    timezone = CreateConfigurationValidSiteURL._get_timezone(
         None,
         input_mode=InputMode.ACCEPT_INPUT,
         handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
@@ -384,7 +414,7 @@ def test_turbo_configuration_get_timezone_found_default_input_empty() -> None:
 
 def test_turbo_configuration_get_default_lang_cli_provided() -> None:
     """Ensures CLI-provided default langauge takes precedence."""
-    default_lang = CreateConfiguration._get_default_lang(
+    default_lang = CreateConfigurationValidSiteURL._get_default_lang(
         "fr",
         input_mode=InputMode.REJECT_INPUT,
         handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
@@ -394,7 +424,7 @@ def test_turbo_configuration_get_default_lang_cli_provided() -> None:
 
 def test_turbo_configuration_get_default_lang_default_used() -> None:
     """Ensures that the default language is used when defaults can be used."""
-    default_lang = CreateConfiguration._get_default_lang(
+    default_lang = CreateConfigurationValidSiteURL._get_default_lang(
         None,
         input_mode=InputMode.REJECT_INPUT,
         handle_defaults_mode=HandleDefaultsMode.USE_DEFAULTS,
@@ -405,7 +435,7 @@ def test_turbo_configuration_get_default_lang_default_used() -> None:
 def test_turbo_configuration_get_default_lang_reject_input() -> None:
     """Ensures error raised when no default can be used and input is not allowed."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_default_lang(
+        CreateConfigurationValidSiteURL._get_default_lang(
             None,
             input_mode=InputMode.REJECT_INPUT,
             handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
@@ -415,7 +445,7 @@ def test_turbo_configuration_get_default_lang_reject_input() -> None:
 @pytest.mark.usefixtures("input_nothing")
 def test_turbo_configuration_get_default_lang_input_empty() -> None:
     """Ensures default language returned when user inputs blank default language."""
-    default_lang = CreateConfiguration._get_default_lang(
+    default_lang = CreateConfigurationValidSiteURL._get_default_lang(
         None,
         input_mode=InputMode.ACCEPT_INPUT,
         handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
@@ -427,7 +457,7 @@ def test_turbo_configuration_get_default_lang_input_empty() -> None:
 def test_turbo_configuration_get_default_lang_input_unparseable() -> None:
     """Ensures error when an unparseable language is provided."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_default_lang(
+        CreateConfigurationValidSiteURL._get_default_lang(
             None,
             input_mode=InputMode.ACCEPT_INPUT,
             handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
@@ -438,7 +468,7 @@ def test_turbo_configuration_get_default_lang_input_unparseable() -> None:
 def test_turbo_configuration_get_default_lang_input_unrecognized() -> None:
     """Ensures error when an unrecognized language is provided."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_default_lang(
+        CreateConfigurationValidSiteURL._get_default_lang(
             None,
             input_mode=InputMode.ACCEPT_INPUT,
             handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
@@ -448,7 +478,7 @@ def test_turbo_configuration_get_default_lang_input_unrecognized() -> None:
 @pytest.mark.usefixtures("input_es")
 def test_turbo_configuration_get_default_lang_input_recognized() -> None:
     """Ensures error when a recognized language is provided."""
-    default_lang = CreateConfiguration._get_default_lang(
+    default_lang = CreateConfigurationValidSiteURL._get_default_lang(
         None,
         input_mode=InputMode.ACCEPT_INPUT,
         handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
@@ -471,12 +501,12 @@ def test_turbo_configuration_validate_site_url(site_url: str, *, valid: bool) ->
     """Ensures an error is raised if and only if the provided site URL is invalid."""
     context = pytest.raises(ConfigurationError) if not valid else nullcontext()
     with context:
-        CreateConfiguration._validate_site_url(site_url)
+        CreateConfigurationValidSiteURL._validate_site_url(site_url)
 
 
 def test_turbo_configuration_get_site_url_cli_provided() -> None:
     """Ensures that the CLI-provided site URL takes precedence."""
-    site_url = CreateConfiguration._get_site_url(
+    site_url = CreateConfigurationValidSiteURL._get_site_url(
         "https://hello-world-123.github.io",
         Path(),
         input_mode=InputMode.REJECT_INPUT,
@@ -488,7 +518,7 @@ def test_turbo_configuration_get_site_url_cli_provided() -> None:
 def test_turbo_configuration_get_site_url_no_user_input() -> None:
     """Ensures error is raised when no way for URL to be obtained."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_site_url(
+        CreateConfigurationValidSiteURL._get_site_url(
             None,
             Path(),
             input_mode=InputMode.REJECT_INPUT,
@@ -498,31 +528,31 @@ def test_turbo_configuration_get_site_url_no_user_input() -> None:
 
 def test_turbo_configuration_get_site_url_valid_path_use_default() -> None:
     """Ensures that when path is valid and defaults used, the URL is appropriate."""
-    site_url = CreateConfiguration._get_site_url(
+    site_url = CreateConfigurationValidSiteURL._get_site_url(
         None,
         Path("valid_website_name"),
         input_mode=InputMode.REJECT_INPUT,
         handle_defaults_mode=HandleDefaultsMode.USE_DEFAULTS,
     )
-    assert site_url == "https://valid-website-name.github.io"
+    assert site_url == "https://default.github.io"
 
 
 @pytest.mark.usefixtures("input_nothing")
 def test_turbo_configuration_get_site_url_valid_path_input_empty() -> None:
     """Ensures that the user can enter nothing and let the default URL be chosen."""
-    site_url = CreateConfiguration._get_site_url(
+    site_url = CreateConfigurationValidSiteURL._get_site_url(
         None,
         Path("valid_website_name"),
         input_mode=InputMode.ACCEPT_INPUT,
         handle_defaults_mode=HandleDefaultsMode.REQUIRE_STANDARD_INPUT,
     )
-    assert site_url == "https://valid-website-name.github.io"
+    assert site_url == "https://default.github.io"
 
 
-def test_turbo_configuration_get_site_url_invalid_path_reject_input() -> None:
+def test_turbo_configuration_get_site_url_default_unavailable_reject_input() -> None:
     """Ensures error raised if input not allowed and website name can't be inferred."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_site_url(
+        CreateConfigurationInvalidSiteURL._get_site_url(
             None,
             Path("^$"),
             input_mode=InputMode.REJECT_INPUT,
@@ -531,10 +561,10 @@ def test_turbo_configuration_get_site_url_invalid_path_reject_input() -> None:
 
 
 @pytest.mark.usefixtures("input_nothing")
-def test_turbo_configuration_get_site_url_invalid_path_input_empty() -> None:
+def test_turbo_configuration_get_site_url_default_unavailable_input_empty() -> None:
     """Ensures error raised if URL can't be inferred and user doesn't enter one."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_site_url(
+        CreateConfigurationInvalidSiteURL._get_site_url(
             None,
             Path("^$"),
             input_mode=InputMode.ACCEPT_INPUT,
@@ -546,7 +576,7 @@ def test_turbo_configuration_get_site_url_invalid_path_input_empty() -> None:
 def test_turbo_configuration_get_site_url_valid_path_input_invalid() -> None:
     """Ensures error raised if URL can be inferred but user enters badly."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_site_url(
+        CreateConfigurationValidSiteURL._get_site_url(
             None,
             Path("valid-website-name"),
             input_mode=InputMode.REJECT_INPUT,
@@ -555,10 +585,10 @@ def test_turbo_configuration_get_site_url_valid_path_input_invalid() -> None:
 
 
 @pytest.mark.usefixtures("input_sam")
-def test_turbo_configuration_get_site_url_invalid_path_input_invalid() -> None:
+def test_turbo_configuration_get_site_url_default_unavailable_input_invalid() -> None:
     """Ensures error raised if URL can't be inferred and user enters badly."""
     with pytest.raises(ConfigurationError):
-        CreateConfiguration._get_site_url(
+        CreateConfigurationInvalidSiteURL._get_site_url(
             None,
             Path("^$"),
             input_mode=InputMode.ACCEPT_INPUT,
@@ -569,7 +599,7 @@ def test_turbo_configuration_get_site_url_invalid_path_input_invalid() -> None:
 @pytest.mark.usefixtures("input_site_name")
 def test_turbo_configuration_get_site_url_valid_path_input_valid() -> None:
     """Ensures error raised if URL can be inferred but user enters differently."""
-    site_url = CreateConfiguration._get_site_url(
+    site_url = CreateConfigurationValidSiteURL._get_site_url(
         None,
         Path("valid-website-name"),
         input_mode=InputMode.ACCEPT_INPUT,
@@ -579,9 +609,9 @@ def test_turbo_configuration_get_site_url_valid_path_input_valid() -> None:
 
 
 @pytest.mark.usefixtures("input_site_name")
-def test_turbo_configuration_get_site_url_invalid_path_input_valid() -> None:
+def test_turbo_configuration_get_site_url_default_unavailable_input_valid() -> None:
     """Ensures error raised if URL can't be inferred and user enters one."""
-    site_url = CreateConfiguration._get_site_url(
+    site_url = CreateConfigurationInvalidSiteURL._get_site_url(
         None,
         Path("^$"),
         input_mode=InputMode.ACCEPT_INPUT,

--- a/src/turbopelican/_utils/shared/tests/test_create.py
+++ b/src/turbopelican/_utils/shared/tests/test_create.py
@@ -14,9 +14,23 @@ from turbopelican._utils.shared.args import (
 from turbopelican._utils.shared.create import update_contents, update_website
 
 
+class CreateConfigurationComplete(CreateConfiguration):
+    @classmethod
+    def _default_site_url(cls, path: Path) -> str | None:
+        """Obtains the default site URL if none is provided by the user explicitly.
+
+        Args:
+            path: The resolved path to the directory where the project is located.
+
+        Returns:
+            The default site URL if it can be obtained.
+        """
+        return path.name
+
+
 @pytest.fixture
-def config(tmp_path: Path) -> CreateConfiguration:
-    return CreateConfiguration(
+def config(tmp_path: Path) -> CreateConfigurationComplete:
+    return CreateConfigurationComplete(
         directory=tmp_path,
         author="Bob",
         site_name="Bob's website",


### PR DESCRIPTION
The default site URL is sometimes needlessly and predictably incorrect. The default should be different when running `turbopelican adorn` rather than `turbopelican init`. In the former case, it should be inferred from the git remote.