### PR TITLE
Link relative to site URL.

### DIFF
--- a/src/turbopelican/_templates/newsite/themes/plain-theme/templates/base.html
+++ b/src/turbopelican/_templates/newsite/themes/plain-theme/templates/base.html
@@ -8,7 +8,7 @@
 	</head>
 	<body>
 		<header>
-			<a href="/">
+			<a href="{{ SITEURL }}">
 				<h1>{{ SITENAME }}</h1>
 			</a>
 		</header>


### PR DESCRIPTION
Originally, the root page was used, but a Pelican site is not always hosted at the root.